### PR TITLE
Enable sdcardfs support for N

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -70,6 +70,9 @@ ro.opengles.version=196608
 ro.sf.lcd_density=420
 ro.qualcomm.cabl=0
 
+# Storage
+ro.sys.sdcardfs=true
+
 # QC vendor extension
 ro.vendor.extension_library=libqti-perfd-client.so
 ro.frp.pst=/dev/block/bootdevice/by-name/config


### PR DESCRIPTION
We need sdcardfs support on N. Please see:

https://github.com/GZR-Kernels/kernel_oneplus_onyx/pull/1
